### PR TITLE
Fixes #16 & #3 - Use local flags for sub-commands instead of persistent flags

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -36,8 +36,8 @@ apps, mh acts on all apps in your mh config.`,
 
 		// Build additional configuration from environment and CLI
 		envCLIConfig := lib.MHConfig{
-			PrintRendered: viper.GetBool("printRendered"),
-			SETValues:     viper.GetStringSlice("set"),
+			PrintRendered: printRendered,
+			SETValues:     setValuesFlag,
 		}
 
 		// Merge configuration from file, environment and CLI into default
@@ -64,10 +64,8 @@ apps, mh acts on all apps in your mh config.`,
 
 func init() {
 	RootCmd.AddCommand(applyCmd)
-	var setValuesFlag []string
 
-	applyCmd.PersistentFlags().BoolP("printRendered", "p", false, "print rendered override values")
-	applyCmd.PersistentFlags().StringSliceVar(&setValuesFlag, "set", nil,
+	applyCmd.Flags().BoolVarP(&printRendered, "printRendered", "p", false, "print rendered override values")
+	applyCmd.Flags().StringSliceVar(&setValuesFlag, "set", nil,
 		`set mh values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)`)
-	viper.BindPFlags(applyCmd.PersistentFlags())
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,12 @@ In other words: We heard you like templates, so we templated your Helm value
 overrides.`,
 }
 
+// Local common flags for sub-commands
+var (
+	setValuesFlag []string
+	printRendered bool
+)
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -59,7 +65,7 @@ func Execute() {
 }
 
 func init() {
-	versionNumber = "v0.7.0"
+	versionNumber = "v0.7.1"
 
 	cobra.OnInitialize(initConfig)
 

--- a/cmd/simulate.go
+++ b/cmd/simulate.go
@@ -36,8 +36,8 @@ apps, mh acts on all apps in your mh config.`,
 
 		// Build additional configuration from environment and CLI
 		envCLIConfig := lib.MHConfig{
-			PrintRendered: viper.GetBool("printRendered"),
-			SETValues:     viper.GetStringSlice("set"),
+			PrintRendered: printRendered,
+			SETValues:     setValuesFlag,
 		}
 
 		// Merge configuration from file, environment and CLI into default
@@ -64,10 +64,8 @@ apps, mh acts on all apps in your mh config.`,
 
 func init() {
 	RootCmd.AddCommand(simulateCmd)
-	var setValuesFlag []string
 
-	simulateCmd.PersistentFlags().BoolP("printRendered", "p", false, "print rendered override values")
-	simulateCmd.PersistentFlags().StringSliceVar(&setValuesFlag, "set", nil,
+	simulateCmd.Flags().BoolVarP(&printRendered, "printRendered", "p", false, "print rendered override values")
+	simulateCmd.Flags().StringSliceVar(&setValuesFlag, "set", nil,
 		`set mh values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)`)
-	viper.BindPFlags(simulateCmd.PersistentFlags())
 }


### PR DESCRIPTION
Fixes #16 & #3 - Use local flags for sub-commands instead of persistent flags.

Reference: https://medium.com/@skdomino/writing-better-clis-one-snake-at-a-time-d22e50e60056