### PR TITLE
Add no-recreate-pods commandline flag

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -36,8 +36,9 @@ apps, mh acts on all apps in your mh config.`,
 
 		// Build additional configuration from environment and CLI
 		envCLIConfig := lib.MHConfig{
-			PrintRendered: printRendered,
-			SETValues:     setValuesFlag,
+			PrintRendered:  printRendered,
+			NoRecreatePods: noRecreatePods,
+			SETValues:      setValuesFlag,
 		}
 
 		// Merge configuration from file, environment and CLI into default
@@ -66,6 +67,7 @@ func init() {
 	RootCmd.AddCommand(applyCmd)
 
 	applyCmd.Flags().BoolVarP(&printRendered, "printRendered", "p", false, "print rendered override values")
+	applyCmd.Flags().BoolVar(&noRecreatePods, "no-recreate-pods", false, "do not recreate pods")
 	applyCmd.Flags().StringSliceVar(&setValuesFlag, "set", nil,
 		`set mh values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)`)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,8 +50,9 @@ overrides.`,
 
 // Local common flags for sub-commands
 var (
-	setValuesFlag []string
-	printRendered bool
+	setValuesFlag  []string
+	printRendered  bool
+	noRecreatePods bool
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -65,7 +66,7 @@ func Execute() {
 }
 
 func init() {
-	versionNumber = "v0.8.0"
+	versionNumber = "v0.9.0"
 
 	cobra.OnInitialize(initConfig)
 

--- a/mhlib/app.go
+++ b/mhlib/app.go
@@ -188,8 +188,10 @@ func (a *App) apply(configFile string, simulate bool) (*[]interface{}, error) {
 	// "if a release by this name doesn't already exist, run an install"
 	cmd = append(cmd, "--install")
 
-	// "performs pods restart for the resource if applicable"
-	cmd = append(cmd, "--recreate-pods")
+	if !a.NoRecreatePods {
+		// "performs pods restart for the resource if applicable"
+		cmd = append(cmd, "--recreate-pods")
+	}
 
 	// "namespace to install the release into. (Defaults to helm default behaviour => kubeconfig checked out ns)"
 	if a.Namespace != "" {

--- a/mhlib/mhConfig.go
+++ b/mhlib/mhConfig.go
@@ -22,12 +22,13 @@ import (
 
 // MHConfig is a set of options used during app deployment.
 type MHConfig struct {
-	Maintainers   []string `yaml:"maintainers"`
-	PrintRendered bool     `yaml:"printRendered"`
-	Simulate      bool     `yaml:"simulate"`
-	TargetContext string   `yaml:"targetContext"`
-	Team          string   `yaml:"team"`
-	SETValues     []string
+	Maintainers    []string `yaml:"maintainers"`
+	PrintRendered  bool     `yaml:"printRendered"`
+	NoRecreatePods bool     `yaml:"noRecreatePods"`
+	Simulate       bool     `yaml:"simulate"`
+	TargetContext  string   `yaml:"targetContext"`
+	Team           string   `yaml:"team"`
+	SETValues      []string
 }
 
 // DefaultMHConfig is the default mh config and will most likely be modified
@@ -39,12 +40,13 @@ type MHConfig struct {
 // 4. Command line flags
 // 5. app-specific overrides in MH_CONFIG.
 var DefaultMHConfig = MHConfig{
-	Maintainers:   []string{"none"},
-	PrintRendered: false,
-	Simulate:      false,
-	TargetContext: "localhost",
-	Team:          "sre",
-	SETValues:     []string{""},
+	Maintainers:    []string{"none"},
+	PrintRendered:  false,
+	NoRecreatePods: false,
+	Simulate:       false,
+	TargetContext:  "localhost",
+	Team:           "sre",
+	SETValues:      []string{""},
 }
 
 // MergeMHConfigs merges an arbitrary number of MHConfigs with rising priority.


### PR DESCRIPTION
MultiHelm by default passes the `--recreate-pods` flag to helm. Provide an option to disable this by passing `--no-recreate-pods` to multihelm.